### PR TITLE
Disallow caching of Swagger spec

### DIFF
--- a/tornado_swirl/settings.py
+++ b/tornado_swirl/settings.py
@@ -25,8 +25,10 @@ default_settings = {
     'tags': [],
 
     'swagger_ui_handlers_headers': [], #These should be list of tuples
-    'swagger_spec_headers': [],
-
+    'swagger_spec_headers': [
+        ('Cache-Control', 'no-cache, no-store, must-revalidate'),
+        ('Pragma', 'no-cache'),
+    ],
     'json_mime_type': 'application/json',
 }
 

--- a/tornado_swirl/views.py
+++ b/tornado_swirl/views.py
@@ -60,7 +60,7 @@ class SwaggerApiHandler(tornado.web.RequestHandler):
 
     def get(self):
         """Get handler"""
-        self.set_header('content-type', 'application/json')
+        self.set_header('content-type', settings.default_settings.get('json_mime_type'))
         apis = self.find_api()  # this is a generator
         servers = []
         server_settings = settings.default_settings.get("servers")


### PR DESCRIPTION
Recently we found that caching HTTP proxy server is caching swagger api spec.
Although it's possible to specify these headers, looks like it's probably a good idea to disallow caching by default.